### PR TITLE
add NLP feature flag

### DIFF
--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -39,10 +39,12 @@ import DateSelectorButton from './DateSelectorButton'
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 import Hint from '~/components/Hint'
 import { useFeature } from '~/root'
+import { feature } from '~/lib/env.server'
 
 import searchImg from 'nasawds/src/img/usa-icons-bg/search--white.svg'
 
 export async function loader({ request: { url } }: DataFunctionArgs) {
+  const useNLP = feature('CIRCULARS_USE_NLP')
   const { searchParams } = new URL(url)
   const query = searchParams.get('query') || undefined
   if (query) {
@@ -58,6 +60,7 @@ export async function loader({ request: { url } }: DataFunctionArgs) {
     limit,
     startDate,
     endDate,
+    useNLP,
   })
 
   return { page, ...results }

--- a/app/routes/_gcn.circulars/circulars.server.ts
+++ b/app/routes/_gcn.circulars/circulars.server.ts
@@ -94,12 +94,14 @@ export async function search({
   limit,
   startDate,
   endDate,
+  useNLP
 }: {
   query?: string
   page?: number
   limit?: number
   startDate?: string
   endDate?: string
+  useNLP?: boolean
 }): Promise<{
   items: CircularMetadata[]
   totalPages: number
@@ -130,7 +132,6 @@ export async function search({
     console.log('Error: ', e)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const nlpSearchQuery = query
     ? {
         bool: {
@@ -157,7 +158,6 @@ export async function search({
       }
     : { match_all: {} }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const searchQuery = {
     bool: {
       must: query
@@ -179,6 +179,7 @@ export async function search({
     },
   }
 
+  const chosenQuery = useNLP ? nlpSearchQuery : searchQuery
   const {
     body: {
       hits: {
@@ -189,7 +190,7 @@ export async function search({
   } = await client.search({
     index: 'circulars',
     body: {
-      query: nlpSearchQuery,
+      query: chosenQuery,
       fields: ['subject'],
       _source: false,
       sort: {


### PR DESCRIPTION
adds feature flag to switch between NLP implementation and standard search. This should also remove the need for the eslint ignore lines since both search constants will be referenced when checking the boolean. Defaults to using standard search implementation when feature flag is not enabled.